### PR TITLE
Feature: CSS Cleanup

### DIFF
--- a/spec/helpers.spec.js
+++ b/spec/helpers.spec.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { resizeContainer, templatingLoop, render, escapeSpecialChars as escape } from '../src/javascripts/lib/helpers'
+import { templatingLoop, render, escapeSpecialChars as escape, resizeAppContainer } from '../src/javascripts/lib/helpers'
 import createRangePolyfill from './polyfills/createRange'
 
 if (!document.createRange) {
@@ -16,7 +16,7 @@ function mockGetTemplate (item) {
 
 describe('resizeContainer', () => {
   it('client.invoke has been called', () => {
-    resizeContainer(client)
+    resizeAppContainer(client)
     expect(client.invoke).toHaveBeenCalled()
   })
 })

--- a/src/index.css
+++ b/src/index.css
@@ -1,34 +1,30 @@
-.loader {
-  left: 50%;
-  position: absolute;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  width: 40px;
+.main {
+  height: 100%;
+  vertical-align: middle;
 }
 
-.btn {
-  width: 85% !important;
-  padding: 5px 10px 5px !important;
-  line-height: 18px !important;
-  color: #2F3941 !important;
-  text-shadow: none !important;
-  background-color: #ffffff !important;
-  background-image: none !important;
-  border: 1px solid #D8DCDE !important;
-  box-shadow: none !important;
+.loader {
+  display: block;
+  margin: auto;
+  width: 25%;
+  height: 25%;
+}
+
+.btn-url {
+  width: 100%;
+  color: #2F3941;
+  background-color: #ffffff;
+  background-image: none;
   white-space: nowrap;
 }
 
-section, ul, li {
+.btn-list {
   text-align: center;
-  background: transparent;
-  margin: 0 !important;
+  width: 90%;
+  margin: auto;
 }
 
-html {
-  overflow: hidden !important;
-}
-
-body {
-  overflow: hidden !important;
+#app {
+  height: 100%;
+  overflow: hidden;
 }

--- a/src/javascripts/lib/helpers.js
+++ b/src/javascripts/lib/helpers.js
@@ -1,13 +1,19 @@
-import { getTicketData } from "./api"
-
 /**
- * Resize App container
+ * Resize App Container
+ *
+ * Resizes the app based off of the app element's size
+ * Allows for custom, overridable, dimensions to be passed as well
  * @param {ZAFClient} client ZAFClient object
- * @param {Number} max max height available to resize to
- * @return {Promise} will resolved after resize
+ * @param {...Object} dimensions - an optional param to override
+ *                                 automatic size calculation
  */
-export function resizeContainer (client, newHeight) {
-  return client.invoke('resize', { height: newHeight })
+export function resizeAppContainer (client, dimensions) {
+  if (Object.dimensions) {
+    return client.invoke('resize', { ...dimensions })
+  }
+
+  const { clientHeight } = document.getElementById('app');
+  return client.invoke('resize', { height: clientHeight });
 }
 
 /**

--- a/src/javascripts/locations/ticket_sidebar.js
+++ b/src/javascripts/locations/ticket_sidebar.js
@@ -6,10 +6,7 @@ let fieldsToWatch = [];
 let app = {};
 
 function getFieldsToWatchFromSettings({ uri_templates }) {
-  console.log('uri_templates', uri_templates);
   return _.reduce(JSON.parse(uri_templates), function (memo, uri) {
-    console.log('uri', uri)
-    console.log('memo', memo);
     const fields = _.map(uri.url.match(/\{\{(.+?)\}\}/g), function (f) { return f.slice(2, -2) })
     return _.union(memo, fields)
   }, [])

--- a/src/javascripts/modules/app.js
+++ b/src/javascripts/modules/app.js
@@ -3,11 +3,9 @@
  **/
 
 import I18n from '../../javascripts/lib/i18n'
-import { resizeContainer, render } from '../../javascripts/lib/helpers'
+import { resizeAppContainer, render } from '../../javascripts/lib/helpers'
 import getDefaultTemplate from '../../templates/default'
 import getContext, { buildTemplatesFromContext, getUrisFromSettings } from './context'
-
-const MAX_HEIGHT = '300px'
 
 class App {
   constructor (client, appData) {
@@ -36,7 +34,7 @@ class App {
   renderTemplates(templates) {
     render('.loader', getDefaultTemplate(templates))
 
-    return resizeContainer(this.client, MAX_HEIGHT)
+    return resizeAppContainer(this.client);
   }
   /**
    * Handle error

--- a/src/javascripts/modules/context.js
+++ b/src/javascripts/modules/context.js
@@ -95,7 +95,6 @@ function parseFirstLastName(user) {
 async function getContext(client) {
   function buildContext(ticket, currentUser) {
     let context = {};
-    console.log('[buildContext - ticket]', ticket);
     context.ticket = ticket;
 
     if (ticket.requester.id) {
@@ -117,7 +116,7 @@ async function getContext(client) {
     }
 
     context.current_user = parseFirstLastName(currentUser);
-    console.log('[buildContext - context]', context);
+
     return context;
   };
 

--- a/src/templates/default.js
+++ b/src/templates/default.js
@@ -4,7 +4,7 @@ function uriMarkup (uri) {
   return (`
     <li>
       <strong class="u-font-family-system u-semibold">
-        <a href="${uri.url}" target="_blank" class="btn">${uri.title}</a>
+        <a href="${uri.url}" target="_blank" class="btn btn-url">${uri.title}</a>
       </strong>
     </li>
   `);
@@ -13,7 +13,7 @@ function uriMarkup (uri) {
 export default function (templateUris) {
   return (`
     <div class="well well-small">
-      <ul>${loop(templateUris, uriMarkup)}</ul>
+      <ul class="btn-list">${loop(templateUris, uriMarkup)}</ul>
     </div>
   `);
 }

--- a/src/templates/iframe.html
+++ b/src/templates/iframe.html
@@ -6,8 +6,8 @@
     <% _.forEach(htmlWebpackPlugin.options.vendorCss, function(css) { %><link href="<%= css %>" rel="stylesheet"><% }); %>
   </head>
 
-  <body>
-    <section data-main class="main">
+  <body id="app">
+    <section class="main">
       <img class="loader" src="spinner.gif"/>
     </section>
     <% _.forEach(htmlWebpackPlugin.options.vendorJs, function(js) { %><script type="text/javascript" src="<%= js %>"></script><% }); %>


### PR DESCRIPTION
**Note that this PR is merging into the app-scaffold feature branch**

This is looking much better now! 

For CSS, in general, it's good practice to stay away from using `!important`, but it's understandable since we're overriding some bootstrap stuff.

Rather than using `!important`, I added a separate CSS class to handle the overrides so that it does not conflict with Bootstraps CSS. By adding `.btn-url` to the class on that `<a>` tag we get to benefit from the default bootstrap styles as well as ability to customize our own. This also allowed us to benefit from the `:hover` css modifier that is within bootstrap. You'll see below in the video that it's much clearer which button you're clicking.

Unfortunately, we do not control the actual iFrame element wrapper which is handled by Zendesk. Hardcoding the `300px` didn't sit right with me because it may work for our implementation but if someone were to add several URL Templates to the inputted JSON the result would have a scroll bar which is not ideal as we want this to expand fully. The changes to the resize function calculate the height based off of the actual space used by the elements. If there were 2 buttons the app would resize to much smaller and visa-versa.

Video of CSS Changes:
![Zendesk](https://user-images.githubusercontent.com/27144805/65275441-f0dd2680-dae2-11e9-9457-4d0500484de9.gif)
