### PR TITLE
Bug: App Initialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "build:dev": "webpack --mode=development",
     "build": "webpack -p --mode=production",
     "lint": "standard",
-    "start": "zat server -p ./dist"
+    "start": "zat server -p ./dist",
+    "package": "zat package -p ./dist",
+    "validate": "zat validate -p ./dist"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/src/javascripts/modules/context.js
+++ b/src/javascripts/modules/context.js
@@ -73,11 +73,11 @@ async function getContext() {
     let context = {};
     context.ticket = ticket;
 
-    if (ticket.requester.id) {
+    if (ticket.requester) {
       context.ticket.requester = await processUserObject(ticket.requester);
     }
 
-    if (ticket.assignee.user.id) {
+    if (ticket.assignee.user) {
       context.ticket.assignee.user = await processUserObject(ticket.assignee.user);
     }
 


### PR DESCRIPTION
In context.js we have checks like  if (ticket.assignee.user.id)

Problem is, that if user is undefined (which is possible), then the app will crash because you’re trying to read a property off of an undefined object.

Also added helpful npm scripts to run `zat` commands