### PR TITLE
Check for null Organization const after API Call

### DIFF
--- a/src/javascripts/modules/context.js
+++ b/src/javascripts/modules/context.js
@@ -97,7 +97,11 @@ async function getContext() {
    */
   if (ticket.organization) {
     const { organization } = await client.request(getOrganizationData(ticket.organization.id));
-    ticket.organization.organization_fields = organization.organization_fields;
+
+    // If the call was successful, add the fields
+    if (organization) {
+      ticket.organization.organization_fields = organization.organization_fields;
+    }
   }
 
   ticket = assignTicketFields(ticket, ticketFields);

--- a/src/javascripts/modules/context.js
+++ b/src/javascripts/modules/context.js
@@ -92,15 +92,23 @@ async function getContext() {
   const ticketFields = await client.request(getTicketData(ticket.id));
 
   /**
-   * Tickets sometimes have a null organization.  If it is not null, get any custom fields for the org
-   * and assign them to the ticket organization object.
+   * Ticket organization is based on the nature of how the ticket was created.  
+   * If an organization is available and we can access it, we'll assign the fields.
+   * 
+   * From Zendesk (https://support.zendesk.com/hc/en-us/articles/203690926-Updating-ticket-requesters-and-organizations):
+   * - When a user who belongs to multiple organizations submits a ticket by email, it is assigned to their 
+   * - default organization. When the user creates a ticket in your Help Center, or when an agent creates a 
+   * - ticket on behalf of the user, the user or agent can select the organization for the ticket.
    */
   if (ticket.organization) {
-    const { organization } = await client.request(getOrganizationData(ticket.organization.id));
+    try {
+      const { organization } = await client.request(getOrganizationData(ticket.organization.id))
 
-    // If the call was successful, add the fields
-    if (organization) {
-      ticket.organization.organization_fields = organization.organization_fields;
+      if (organization) {
+        ticket.organization.organization_fields = organization.organization_fields;
+      }
+    } catch (error) {
+      console.error(`Error retrieving Organization fields for ${ticket.organization.id}: ${error}`)
     }
   }
 


### PR DESCRIPTION
# Description

Several of our agents noticed the URL Builder App not working, and provided screenshots of the Chrome Developer Tools console.  It appears we're getting HTTP 403 responses to the `/api/v2/organizations/{organizationId}.json` call for people with Agent and Agent-based roles.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Open a ticket as a logged in user whose permission level is "Agent".  See if the URL Builder App opens properly.

**Test Configuration**:

* Browser Version: Google Chrome Version 77.0.3865.90 (Official Build) (64-bit)
* Operating System: macOS Mojave 10.14.6

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes