### PR TITLE
Adding Zendesk Docs and Remove Private Flag

### DIFF
--- a/src/ZENDESK_MANDATORY_SERVICE_TERMS
+++ b/src/ZENDESK_MANDATORY_SERVICE_TERMS
@@ -1,0 +1,13 @@
+ Below is a copy of the Mandatory Service Terms from the [Zendesk Application Developer and API License Agreement](https://www.zendesk.com/company/customers-partners/application-developer-api-license-agreement/)
+
+# 4.4 Mandatory Service Terms:
+
+(i) The Licensee is the licensor of the Application and Zendesk is not a party to the App Terms of Service.
+
+(ii) Except as otherwise limited by any App Terms of Service imposed or required by the Licensee, Licensee grants Subscriber a perpetual, worldwide, non-exclusive, non-transferable and non-sublicensable license to access, deploy, use and integrate the Application in connection with Subscriber’s active Account for a Service.
+
+(iii) Any information that Licensee collects, stores and processes from Subscriber or the systems Subscriber uses to access or deploy the Application, including Service Data, will be subject to the App Terms of Service, privacy notice, or similar terms that the Licensor provides to Subscriber, and will not be subject to the Privacy Policy.
+
+(iv) Subscriber may not modify, reverse engineer, decompile or disassemble the Application in whole or in part, or create any derivative works from or sublicense any rights in the Application, unless otherwise expressly authorized in writing by Licensor.
+
+(v) Each of Subscriber and the Licensor shall maintain all rights, title and interest in and to all its respective patents, inventions, copyrights, trademarks, domain names, trade secrets, know-how and any other intellectual property and/or proprietary rights (collectively, “IP Rights”). The rights granted to Subscriber to use the Application under these App Terms of Service do not convey any additional rights in the Application or Licensor Service, or in any IP Rights associated therewith. Subject only to limited rights to access and use the Application as expressly stated herein, all rights, title and interest in and to the Application and all hardware, software and other components of or used to provide the Application, including all related IP Rights, will remain with and belong exclusively to the Licensor. Licensor shall have a royalty-free, worldwide, transferable, sub-licensable, irrevocable and perpetual license to incorporate into the Application or otherwise use any suggestions, enhancement requests, recommendations or other feedback it receives from Subscriber.

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,7 +6,6 @@
     "url": "https://www.ibotta.com/"
   },
   "defaultLocale": "en",
-  "private": true,
   "location": {
     "support": {
       "ticket_sidebar": "assets/iframe.html",


### PR DESCRIPTION
# Description

Adding Zendesk's mandatory service terms along with removing the private flag from the manifest.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes