### PR TITLE
Manifest Requires Private

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,6 +5,7 @@
     "email": "osscompliance@ibotta.com",
     "url": "https://www.ibotta.com/"
   },
+  "private": false,
   "defaultLocale": "en",
   "location": {
     "support": {


### PR DESCRIPTION
# Description

Mistakingly, I didn't check the [manifest reference](https://developer.zendesk.com/apps/docs/developer-guide/manifest#private) and it appears `private: false` is required.

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes